### PR TITLE
Fix NullPointerException when parameterBitLength is null in isParameterModified

### DIFF
--- a/src/main/java/spice86/generator/parsing/ParsedInstructionBuilder.java
+++ b/src/main/java/spice86/generator/parsing/ParsedInstructionBuilder.java
@@ -223,7 +223,7 @@ public class ParsedInstructionBuilder extends ObjectWithContextAndLog {
   private boolean isParameterModified(ParsedInstruction parsedInstruction,
       Map<Integer, Set<Integer>> possibleInstructionByteValues, Integer parameter,
       Integer parameterBitLength, Integer parameterOffset) {
-    if (parameter == null) {
+    if (parameter == null || parameterBitLength == null) {
       // No parameter, nothing to check
       return false;
     }


### PR DESCRIPTION
In ParsedInstructionBuilder.isParameterModified(), the null check only tested parameter but not parameterBitLength. When Ghidra parses certain instructions, parameterBitLength can be null while parameter is not, causing a NullPointerException at int length = parameterBitLength / 8.
Fix: add || parameterBitLength == null to the null guard.
Discovered while using the plugin to generate C# overrides for Test Drive 3 (DOS, 1990).